### PR TITLE
feat: add kinematic collision detection fallback

### DIFF
--- a/tmrl/custom/interfaces/TM2020Interface.py
+++ b/tmrl/custom/interfaces/TM2020Interface.py
@@ -10,6 +10,7 @@ from collections import deque
 
 import cv2
 import numpy as np
+import threading
 from gymnasium import spaces
 from loguru import logger
 from rtgym import RealTimeGymInterface
@@ -113,8 +114,9 @@ class TM2020Interface(RealTimeGymInterface):
             min_nb_steps_before_failure if min_nb_steps_before_failure is not None else 70
         )
         self.min_nb_steps_before_failure = cfg.REWARD_CONFIG.get("MIN_STEPS", _default_min_steps)
+        self._crash_lock = threading.Lock()
+        self._async_rumble_event = False
         self.crash_cooldown = 0
-        self.crash_curr = 0
         _alg_cfg = cfg.TMRL_CONFIG.get("ALG", {})
         self.discrete_action_table: list[np.ndarray] | None = None
         if _alg_cfg.get("ALGORITHM") in ("IQN", "SDSAC"):
@@ -215,24 +217,25 @@ class TM2020Interface(RealTimeGymInterface):
             self.client = TM2020OpenPlanetClient()
         self.is_crashed = False
         self.crash_cooldown = 0
-        self.crash_curr = self.crash_cooldown
 
     def crash_callback(self, client, target, large_motor, small_motor, led_number, user_data):
         """Callback for detecting crashes via gamepad vibration."""
-        self.is_crashed = large_motor > 100 and self.crash_cooldown <= 0
-        if self.is_crashed:
-            self.crash_cooldown = 10
+        if large_motor > 100:
+            with self._crash_lock:
+                self._async_rumble_event = True
 
-    def crash_fallback(self, current_speed):
+    def crash_fallback(self, current_speed, jerk):
         """
         Kinematic fallback for collision detection in case of gamepad rumble malfunction.
 
         Calculates the velocity drop between the previous and current frame. If the
         deceleration exceeds a dynamic threshold (flat base drop + relative speed drop),
-        the environment is flagged as crashed.
+        and is accompanied by a sharp negative jerk, the environment is flagged as crashed.
 
         Args:
             current_speed (float): The current speed of the agent in km/h.
+            jerk (float, optional): The rate of change of acceleration. Used to distinguish
+                smooth deceleration from sudden impacts. Defaults to 0.0.
 
         Mutates:
             self.is_crashed (bool): Set to True if a kinematic collision is detected.
@@ -245,9 +248,63 @@ class TM2020Interface(RealTimeGymInterface):
         speed_factor = 0.20
         dynamic_threshold = base_drop + (last_speed * speed_factor)
 
-        if delta_v > dynamic_threshold:
+        if delta_v > dynamic_threshold and jerk <= -1.45:
             self.is_crashed = True
             self.crash_cooldown = 10
+
+    def _sync_crash_state(self):
+        """
+        Synchronizes the asynchronous crash event state with the main environment step.
+
+        Safely consumes the latching flag set by the background gamepad telemetry thread.
+        By acquiring a brief thread lock, it reads and clears the hardware rumble event
+        to prevent race conditions. If an impact was detected and the agent is not currently
+        in a cooldown period, the main crash state is updated.
+
+        Mutates:
+            self._async_rumble_event (bool): Cleared to False after being read.
+            self.is_crashed (bool): Set to True if an asynchronous crash event was triggered.
+            self.crash_cooldown (int): Set to 10 to debounce subsequent collisions.
+        """
+        with self._crash_lock:
+            rumble_triggered = self._async_rumble_event
+            self._async_rumble_event = False
+
+        if rumble_triggered and self.crash_cooldown == 0:
+            self.is_crashed = True
+            self.crash_cooldown = 10
+
+    def cooldown_control(self):
+        """
+        Manages the post-crash state at the end of an environment step.
+
+        This function ensures that the crash signal acts as a single-frame impulse
+        by unconditionally resetting the crash flag. It also handles the decrement
+        of the grace period (cooldown) following a collision.
+
+        Mutates:
+            self.is_crashed (bool): Unconditionally resets to False for the next frame.
+            self.crash_cooldown (int): Decrements by 1 if currently greater than 0.
+        """
+        self.is_crashed = False
+        if self.crash_cooldown > 0:
+            self.crash_cooldown -= 1
+
+    def get_speed_in_kmph(self, speed):
+        """
+        Converts the vehicle's speed from meters per second to kilometers per hour.
+
+        This function applies a standard 3.6 multiplier to the raw telemetry speed,
+        translating it into a standardized metric unit suitable for observation
+        scaling, reward shaping, or human-readable logging.
+
+        Args:
+            speed (float): The raw speed value expressed in meters per second (m/s).
+
+        Returns:
+            float: The calculated speed expressed in kilometers per hour (km/h).
+        """
+        return speed * 3.6
 
     def initialize(self):
         """Calls initialize_common and sets the interface as initialized."""
@@ -351,6 +408,9 @@ class TM2020Interface(RealTimeGymInterface):
         self.reset_race()
         self.is_crashed = False
         self.crash_cooldown = 0
+        self._last_speed_kmh = 0
+        with self._crash_lock:
+            self._async_rumble_event = False
         time_sleep = (
             max(0, cfg.SLEEP_TIME_AT_RESET - 0.1) if self.gamepad else cfg.SLEEP_TIME_AT_RESET
         )

--- a/tmrl/custom/interfaces/TM2020Interface.py
+++ b/tmrl/custom/interfaces/TM2020Interface.py
@@ -221,7 +221,6 @@ class TM2020Interface(RealTimeGymInterface):
         """Callback for detecting crashes via gamepad vibration."""
         self.is_crashed = large_motor > 100 and self.crash_cooldown <= 0
         if self.is_crashed:
-            logger.debug("crashed: True (episode will terminate)")
             self.crash_cooldown = 10
 
     def crash_fallback(self, current_speed):

--- a/tmrl/custom/interfaces/TM2020Interface.py
+++ b/tmrl/custom/interfaces/TM2020Interface.py
@@ -234,7 +234,7 @@ class TM2020Interface(RealTimeGymInterface):
 
         Args:
             current_speed (float): The current speed of the agent in km/h.
-            jerk (float, optional): The rate of change of acceleration. Used to distinguish
+            jerk (float): The rate of change of acceleration. Used to distinguish
                 smooth deceleration from sudden impacts. Defaults to 0.0.
 
         Mutates:

--- a/tmrl/custom/interfaces/TM2020Interface.py
+++ b/tmrl/custom/interfaces/TM2020Interface.py
@@ -224,6 +224,32 @@ class TM2020Interface(RealTimeGymInterface):
             logger.debug("crashed: True (episode will terminate)")
             self.crash_cooldown = 10
 
+    def crash_fallback(self, current_speed):
+        """
+        Kinematic fallback for collision detection in case of gamepad rumble malfunction.
+
+        Calculates the velocity drop between the previous and current frame. If the
+        deceleration exceeds a dynamic threshold (flat base drop + relative speed drop),
+        the environment is flagged as crashed.
+
+        Args:
+            current_speed (float): The current speed of the agent in km/h.
+
+        Mutates:
+            self.is_crashed (bool): Set to True if a kinematic collision is detected.
+            self.crash_cooldown (int): Set to 10 to debounce hardware callbacks.
+        """
+        last_speed = getattr(self, "_last_speed_kmh", current_speed)
+        delta_v = last_speed - current_speed
+
+        base_drop = 20.0
+        speed_factor = 0.20
+        dynamic_threshold = base_drop + (last_speed * speed_factor)
+
+        if delta_v > dynamic_threshold:
+            self.is_crashed = True
+            self.crash_cooldown = 10
+
     def initialize(self):
         """Calls initialize_common and sets the interface as initialized."""
         self.initialize_common()
@@ -324,6 +350,8 @@ class TM2020Interface(RealTimeGymInterface):
         else:
             self.send_control(self.get_default_action())
         self.reset_race()
+        self.is_crashed = False
+        self.crash_cooldown = 0
         time_sleep = (
             max(0, cfg.SLEEP_TIME_AT_RESET - 0.1) if self.gamepad else cfg.SLEEP_TIME_AT_RESET
         )

--- a/tmrl/custom/interfaces/TM2020InterfaceIMPALA.py
+++ b/tmrl/custom/interfaces/TM2020InterfaceIMPALA.py
@@ -137,11 +137,10 @@ class TM2020InterfaceIMPALA(TM2020Interface):
         obs must be a list of numpy arrays
         """
         data, img = self.grab_data_and_img()
-        # print(f"data: {data}")
         cur_cp = int(data[0])
         cur_lap = int(data[1])
 
-        speed = np.array([data[2]], dtype="float32")
+        speed_kmh = data[2] * 3.6
 
         pos = np.array([data[3], data[4], data[5]], dtype="float32")
 
@@ -161,10 +160,14 @@ class TM2020InterfaceIMPALA(TM2020Interface):
 
         gear = np.array([data[18]], dtype="float32")
 
+        if not self.is_crashed:
+            self.crash_fallback(speed_kmh)
+        self._last_speed_kmh = speed_kmh
+
         rew, terminated, failure_counter, reward_sum = self.reward_function.compute_reward(
             pos=pos,  # position x,y,z
             crashed=bool(self.is_crashed),
-            speed=speed[0],
+            speed=speed_kmh,
             next_cp=self.cur_checkpoint < cur_cp,
             next_lap=self.cur_lap < cur_lap,
         )
@@ -198,7 +201,7 @@ class TM2020InterfaceIMPALA(TM2020Interface):
             info["position_patched"] = True
 
         observation = [
-            speed,
+            speed_kmh,
             acceleration,
             jerk,
             race_progress,

--- a/tmrl/custom/interfaces/TM2020InterfaceIMPALAwoImages.py
+++ b/tmrl/custom/interfaces/TM2020InterfaceIMPALAwoImages.py
@@ -107,7 +107,7 @@ class TM2020InterfaceIMPALAwoImages(TM2020Interface):
         cur_cp = int(data[0])
         cur_lap = int(data[1])
 
-        speed = np.array([data[2]], dtype="float32")
+        speed_kmh = data[2] * 3.6
 
         pos = np.array([data[3], data[4], data[5]], dtype="float32")
 
@@ -129,10 +129,14 @@ class TM2020InterfaceIMPALAwoImages(TM2020Interface):
 
         end_of_track = bool(data[9])
 
+        if not self.is_crashed:
+            self.crash_fallback(speed_kmh)
+        self._last_speed_kmh = speed_kmh
+
         rew, terminated, failure_counter, reward_sum = self.reward_function.compute_reward(
             pos=pos,
             crashed=bool(self.is_crashed),
-            speed=speed[0],
+            speed=speed_kmh,
             next_cp=self.cur_checkpoint < cur_cp,
             next_lap=self.cur_lap < cur_lap,
             end_of_track=end_of_track,
@@ -166,7 +170,7 @@ class TM2020InterfaceIMPALAwoImages(TM2020Interface):
             info["position_patched"] = True
 
         observation = [
-            speed,
+            speed_kmh,
             acceleration,
             jerk,
             race_progress,

--- a/tmrl/custom/interfaces/TM2020InterfaceSophy.py
+++ b/tmrl/custom/interfaces/TM2020InterfaceSophy.py
@@ -244,20 +244,23 @@ class TM2020InterfaceIMPALASophy(TM2020Interface):
         Returns:
             tuple: A tuple containing (observation, reward, terminated, info).
         """
+        # TODO: refactor to grab all data explicitly like TQC interface
         data = self.grab_data()
+        speed_kmh = data[2] * 3.6
         cur_cp = int(data[_IDX_CHECKPOINT])
         cur_lap = int(data[_IDX_LAP])
         end_of_track = bool(data[_IDX_END_OF_TRACK])
 
-        self.is_crashed = bool(data[_IDX_CRASHED])
-        self._last_speed_kmh = float(data[_IDX_SPEED] * 3.6)
+        if not self.is_crashed:
+            self.crash_fallback(speed_kmh)
+        self._last_speed_kmh = speed_kmh
 
         d = self._parse_data(data)
 
         rew, terminated, failure_counter, reward_sum = self.reward_function.compute_reward(
             pos=d["pos"],
             crashed=bool(self.is_crashed),
-            speed=d["speed"][0],
+            speed=speed_kmh,
             next_cp=self.cur_checkpoint < cur_cp,
             next_lap=self.cur_lap < cur_lap,
             end_of_track=end_of_track,

--- a/tmrl/custom/interfaces/TM2020InterfaceTQC.py
+++ b/tmrl/custom/interfaces/TM2020InterfaceTQC.py
@@ -56,7 +56,7 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
         self._sync_crash_state()
 
         if not self.is_crashed and self.crash_cooldown == 0:
-            self.crash_fallback(speed_kmh, jerk)
+            self.crash_fallback(speed_kmh, telemetry.jerk)
         self._last_speed_kmh = speed_kmh
 
 
@@ -249,7 +249,7 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             track_list = [x / cfg.OBS_TRACK_SCALE for x in track_list]
         track_info = [np.array(track_list, dtype="float32")]
 
-        self.counter_ = [
+        observation = [
             speed,
             acceleration,
             jerk,
@@ -264,7 +264,7 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             slip_coef,
             failure_counter,
         ]
-        observation = self.counter_
+
         if curvature_list is not None:
             curv = np.clip(np.array(curvature_list, dtype="float32") * 10.0, -1.0, 1.0)
             observation.append(curv)

--- a/tmrl/custom/interfaces/TM2020InterfaceTQC.py
+++ b/tmrl/custom/interfaces/TM2020InterfaceTQC.py
@@ -33,7 +33,6 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             tuple: A tuple containing (observation, reward, terminated, info).
         """
         data = self.grab_data()
-        self.is_crashed = bool(data[18])
         cur_cp = int(data[0])
         cur_lap = int(data[1])
 
@@ -51,6 +50,10 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
         steer_angle = np.array(data[14:16], dtype="float32")
         slip_coef = np.array(data[16:18], dtype="float32")
         gear = np.array([data[19] / 5.0], dtype="float32")
+
+        if not self.is_crashed:
+            self.crash_fallback(speed_kmh)
+        self._last_speed_kmh = speed_kmh
 
         rew, terminated, failure_counter, reward_sum = self.reward_function.compute_reward(
             pos=pos,
@@ -117,7 +120,7 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             track_list = [x / cfg.OBS_TRACK_SCALE for x in track_list]
         track_info = [np.array(track_list, dtype="float32")]
 
-        if not self.is_crashed:
+        if self.crash_cooldown > 0:
             self.crash_cooldown -= 1
 
         race_progress = np.array([race_progress], dtype="float32")

--- a/tmrl/custom/interfaces/TM2020InterfaceTQC.py
+++ b/tmrl/custom/interfaces/TM2020InterfaceTQC.py
@@ -3,6 +3,7 @@ import numpy as np
 from gymnasium import spaces
 
 import tmrl.config as cfg
+from tmrl.custom.tm.telemetry import Telemetry
 from tmrl.custom.interfaces.TM2020InterfaceSophy import TM2020InterfaceIMPALASophy
 from tmrl.custom.tm.utils.tools import TM2020OpenPlanetClient
 
@@ -33,41 +34,48 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             tuple: A tuple containing (observation, reward, terminated, info).
         """
         data = self.grab_data()
-        cur_cp = int(data[0])
-        cur_lap = int(data[1])
+        telemetry = Telemetry(*data)
 
-        speed_kmh = data[2] * 3.6
+        cur_cp = telemetry.cp
+        cur_lap = telemetry.lap
+        speed_kmh = self.get_speed_in_kmph(telemetry.speed)
         speed = np.array([speed_kmh / cfg.OBS_SPEED_SCALE], dtype="float32")
-        pos = np.array([data[3], data[4], data[5]], dtype="float32")
-        input_steer = np.array([data[6]], dtype="float32")
-        input_gas_pedal = np.array([data[7]], dtype="float32")
-        input_brake = np.array([data[8]], dtype="float32")
-        end_of_track = bool(data[9])
-        acceleration = np.array([data[10]], dtype="float32")
-        jerk = np.array([data[11]], dtype="float32")
-        aim_yaw = np.array([data[12]], dtype="float32")
-        aim_pitch = np.array([data[13]], dtype="float32")
-        steer_angle = np.array(data[14:16], dtype="float32")
-        slip_coef = np.array(data[16:18], dtype="float32")
-        gear = np.array([data[19] / 5.0], dtype="float32")
+        pos = np.array([telemetry.pos_x, telemetry.pos_y, telemetry.pos_z], dtype="float32")
+        input_steer = np.array([telemetry.input_steer], dtype = "float32")
+        input_gas_pedal = np.array([telemetry.input_gas], dtype="float32")
+        input_brake = np.array([telemetry.input_brake], dtype="float32")
+        end_of_track = bool(telemetry.is_finished)
+        acceleration = np.array([telemetry.acceleration], dtype="float32")
+        jerk = np.array([telemetry.jerk], dtype="float32")
+        aim_yaw = np.array([telemetry.aim_yaw], dtype="float32")
+        aim_pitch = np.array([telemetry.aim_pitch], dtype="float32")
+        steer_angle = np.array([telemetry.fl_steer_angle, telemetry.fr_steer_angle], dtype="float32")
+        slip_coef = np.array([telemetry.fl_slip_coef, telemetry.fr_slip_coef], dtype="float32")
+        gear = np.array([telemetry.gear / 5.0], dtype="float32")
 
-        if not self.is_crashed:
-            self.crash_fallback(speed_kmh)
+        self._sync_crash_state()
+
+        if not self.is_crashed and self.crash_cooldown == 0:
+            self.crash_fallback(speed_kmh, jerk)
         self._last_speed_kmh = speed_kmh
 
-        rew, terminated, failure_counter, reward_sum = self.reward_function.compute_reward(
+
+        self.reward = self.reward_function.compute_reward(
             pos=pos,
             crashed=self.is_crashed,
             speed=speed_kmh,
             next_cp=self.cur_checkpoint < cur_cp,
             next_lap=self.cur_lap < cur_lap,
             end_of_track=end_of_track,
-            input_brake=float(data[8]),
-            aim_yaw=float(data[12]),
-            input_steer=float(data[6]),
-            gear=float(data[19]),
+            input_brake=telemetry.input_brake,
+            aim_yaw=telemetry.aim_yaw,
+            input_steer=telemetry.input_steer,
+            gear=float(telemetry.gear),
             slip_angle_deg=None,
         )
+        rew, terminated, failure_counter, reward_sum = self.reward
+
+        self.cooldown_control()
         self._dbg_last_step = {
             "terminated": bool(terminated),
             "end_of_track": bool(end_of_track),
@@ -119,9 +127,6 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
         if cfg.OBS_TRACK_SCALE != 1.0:
             track_list = [x / cfg.OBS_TRACK_SCALE for x in track_list]
         track_info = [np.array(track_list, dtype="float32")]
-
-        if self.crash_cooldown > 0:
-            self.crash_cooldown -= 1
 
         race_progress = np.array([race_progress], dtype="float32")
         max_count = max(
@@ -197,19 +202,22 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
         self.cur_lap = 0
         self.cur_checkpoint = 0
 
-        speed_kmh = data[2] * 3.6
+
+        telemetry = Telemetry(*data)
+
+        speed_kmh = self.get_speed_in_kmph(telemetry.speed)
         speed = np.array([speed_kmh / cfg.OBS_SPEED_SCALE], dtype="float32")
-        pos = np.array([data[3], data[4], data[5]], dtype="float32")
-        input_steer = np.array([data[6]], dtype="float32")
-        input_gas_pedal = np.array([data[7]], dtype="float32")
-        input_brake = np.array([data[8]], dtype="float32")
-        acceleration = np.array([data[10]], dtype="float32")
-        jerk = np.array([data[11]], dtype="float32")
-        aim_yaw = np.array([data[12]], dtype="float32")
-        aim_pitch = np.array([data[13]], dtype="float32")
-        steer_angle = np.array(data[14:16], dtype="float32")
-        slip_coef = np.array(data[16:18], dtype="float32")
-        gear = np.array([data[19] / 5.0], dtype="float32")
+        pos = np.array([telemetry.pos_x, telemetry.pos_y, telemetry.pos_z], dtype="float32")
+        input_steer = np.array([telemetry.input_steer], dtype="float32")
+        input_gas_pedal = np.array([telemetry.input_gas], dtype="float32")
+        input_brake = np.array([telemetry.input_brake], dtype="float32")
+        acceleration = np.array([telemetry.acceleration], dtype="float32")
+        jerk = np.array([telemetry.jerk], dtype="float32")
+        aim_yaw = np.array([telemetry.aim_yaw], dtype="float32")
+        aim_pitch = np.array([telemetry.aim_pitch], dtype="float32")
+        steer_angle = np.array([telemetry.fl_steer_angle, telemetry.fr_steer_angle], dtype="float32")
+        slip_coef = np.array([telemetry.fl_slip_coef, telemetry.fr_slip_coef], dtype="float32")
+        gear = np.array([telemetry.gear / 5.0], dtype="float32")
 
         failure_counter = np.array([0.0], dtype="float32")
         race_progress = np.array([0.0], dtype="float32")
@@ -241,7 +249,7 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             track_list = [x / cfg.OBS_TRACK_SCALE for x in track_list]
         track_info = [np.array(track_list, dtype="float32")]
 
-        observation = [
+        self.counter_ = [
             speed,
             acceleration,
             jerk,
@@ -256,6 +264,7 @@ class TM2020InterfaceTQC(TM2020InterfaceIMPALASophy):
             slip_coef,
             failure_counter,
         ]
+        observation = self.counter_
         if curvature_list is not None:
             curv = np.clip(np.array(curvature_list, dtype="float32") * 10.0, -1.0, 1.0)
             observation.append(curv)

--- a/tmrl/custom/tm/telemetry.py
+++ b/tmrl/custom/tm/telemetry.py
@@ -1,0 +1,35 @@
+"""
+Telemetry data structure for the environment state.
+
+This NamedTuple encapsulates a single frame of raw telemetry data, including:
+race progress (cp, lap), kinematics (speed, pos, acceleration, jerk),
+driver inputs (input_steer, input_gas, input_brake), vehicle dynamics
+(aim, wheel steer angles, slip coefficients, gear), and event flags
+(is_finished, is_crashed_raw).
+
+Use this structured object to access telemetry fields securely by name
+instead of raw tuple indexing.
+"""
+from typing import NamedTuple
+
+class Telemetry(NamedTuple):
+    cp: float
+    lap: float
+    speed: float
+    pos_x: float
+    pos_y: float
+    pos_z: float
+    input_steer: float
+    input_gas: float
+    input_brake: bool
+    is_finished: bool
+    acceleration: float
+    jerk: float
+    aim_yaw: float
+    aim_pitch: float
+    fl_steer_angle: float
+    fr_steer_angle: float
+    fl_slip_coef: float
+    fr_slip_coef: float
+    is_crashed_raw: bool
+    gear: float

--- a/tmrl/custom/tm/telemetry.py
+++ b/tmrl/custom/tm/telemetry.py
@@ -13,8 +13,8 @@ instead of raw tuple indexing.
 from typing import NamedTuple
 
 class Telemetry(NamedTuple):
-    cp: float
-    lap: float
+    cp: int
+    lap: int
     speed: float
     pos_x: float
     pos_y: float


### PR DESCRIPTION
Implemented a hybrid collision detection system to handle potential gamepad rumble malfunctions.

- Added a velocity-based fallback that compares the delta between the last known and current speed against a dynamic threshold to reliably assess crashes.
- Enforced state isolation by resetting the `is_crashed` flag and `crash_cooldown` during environment resets, preventing state leakage between consecutive episodes.

#### TODO
- Port these changes to non-TQC interfaces.